### PR TITLE
ActiveHash導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,3 +54,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'pry-rails'
+gem 'active_hash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.1.0)
+      activesupport (>= 5.0.0)
     activejob (6.0.3.5)
       activesupport (= 6.0.3.5)
       globalid (>= 0.3.6)
@@ -227,6 +229,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_hash
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,19 @@
+class Category < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '-選択してください-' },
+    { id: 2, name: '固定費' },
+    { id: 3, name: '自炊の食費' },
+    { id: 4, name: 'コンビニ' },
+    { id: 5, name: '外食費' },
+    { id: 6, name: '日用品' },
+    { id: 7, name: '医療費' },
+    { id: 8, name: '交通費' },
+    { id: 9, name: '服飾費' },
+    { id: 10, name: '美容費' }
+    { id: 11, name: 'その他' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :orders
+
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,2 +1,7 @@
 class Order < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :category
+
+  validates :date, :amount, presence: true
+  validates :category_id, numericality: { other_than: 1 } 
 end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
ActiveHashを導入

# Why
categoryについてはデータベースへ保存せず、idで種別の管理を行うため